### PR TITLE
feat: change domains to single-level subdomains

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -16,10 +16,10 @@ services:
       - traefik.http.services.traefik-dashboard.loadbalancer.server.port=8080
       # Make Traefik use this domain (from an environment variable) in HTTP
       - traefik.http.routers.traefik-dashboard-http.entrypoints=http
-      - traefik.http.routers.traefik-dashboard-http.rule=Host(`traefik.${DOMAIN?Variable not set}`)
+      - traefik.http.routers.traefik-dashboard-http.rule=Host(`traefik-${DOMAIN?Variable not set}`)
       # traefik-https the actual router using HTTPS
       - traefik.http.routers.traefik-dashboard-https.entrypoints=https
-      - traefik.http.routers.traefik-dashboard-https.rule=Host(`traefik.${DOMAIN?Variable not set}`)
+      - traefik.http.routers.traefik-dashboard-https.rule=Host(`traefik-${DOMAIN?Variable not set}`)
       - traefik.http.routers.traefik-dashboard-https.tls=true
       # Use the "le" (Let's Encrypt) resolver created below
       - traefik.http.routers.traefik-dashboard-https.tls.certresolver=le

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,10 @@ services:
       - traefik.enable=true
       - traefik.docker.network=traefik-public
       - traefik.constraint-label=traefik-public
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.rule=Host(`adminer.${DOMAIN?Variable not set}`)
+      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.rule=Host(`adminer-${DOMAIN?Variable not set}`)
       - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.entrypoints=http
       - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.middlewares=https-redirect
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.rule=Host(`adminer.${DOMAIN?Variable not set}`)
+      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.rule=Host(`adminer-${DOMAIN?Variable not set}`)
       - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.entrypoints=https
       - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.tls=true
       - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.tls.certresolver=le

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ But you have to configure a couple things first.
 
 - Have a remote server ready and available.
 - Configure the DNS records of your domain to point to the IP of the server you just created.
-- Configure a wildcard subdomain for your domain, so that you can have multiple subdomains for different services, e.g. `*.project.example.com`. This will be useful for accessing different components, like `traefik.project.example.com`, `adminer.project.example.com`, etc. And also for `staging`, like `staging.project.example.com`, `staging.adminer.project.example.com`, etc.
+- Configure a wildcard subdomain for your domain, so that you can have multiple subdomains for different services, e.g. `*.project.example.com`. This will be useful for accessing different components, like `traefik.project.example.com`, `adminer.project.example.com`, etc. And also for `staging`, like `staging.project.example.com`, `staging.adminer.project.example.com`, etc. Note that this wouldn't be necessary if you have domains of the format similar to `adminer-staging-project.example.com`, `traefik-project.example.com`, etc.
 - Install and configure [Docker](https://docs.docker.com/engine/install/) on the remote server (Docker Engine, not Docker Desktop).
 
 ## Public Traefik
@@ -281,9 +281,11 @@ Replace `project.example.com` with your domain.
 
 ### Main Traefik Dashboard
 
-Traefik UI: `https://traefik.project.example.com`
+Traefik UI: `https://traefik-project.example.com`
 
 ### Production
+
+When `DOMAIN_PRODUCTION=project.example.com`:
 
 Frontend: `https://project.example.com`
 
@@ -291,14 +293,16 @@ Backend API docs: `https://project.example.com/docs`
 
 Backend API base URL: `https://project.example.com/api/`
 
-Adminer: `https://adminer.project.example.com`
+Adminer: `https://adminer-project.example.com`
 
 ### Staging
 
-Frontend: `https://staging.project.example.com`
+When `DOMAIN_STAGING=staging-project.example.com`:
 
-Backend API docs: `https://staging.project.example.com/docs`
+Frontend: `https://staging-project.example.com`
 
-Backend API base URL: `https://staging.project.example.com/api/`
+Backend API docs: `https://staging-project.example.com/docs`
 
-Adminer: `https://adminer.staging.project.example.com`
+Backend API base URL: `https://staging-project.example.com/api/`
+
+Adminer: `https://adminer-staging-project.example.com`


### PR DESCRIPTION
We convert to single-level subdomains (i.e. `staging.scheduler.davidsha.me -> staging-scheduler.davidsha.me`) so that we can avoid paying for multi-level subdomains from Cloudflare. More specifically, we avoid having to pay for ["Total TLS" which comes from a $10/mo Advanced Certificate Manager plan](https://developers.cloudflare.com/ssl/troubleshooting/version-cipher-mismatch/#multi-level-subdomains).


![image](https://github.com/d4vidsha/scheduler/assets/70577814/668ec4b3-fa45-4cba-9a8c-df83ff26ceeb)
