### PR TITLE
feat: add click, hold and swipe gestures to TaskList items

### DIFF
--- a/frontend/src/components/calendar/FullCalendarView.tsx
+++ b/frontend/src/components/calendar/FullCalendarView.tsx
@@ -501,9 +501,7 @@ export default function FullCalendarView({
                 >
                   {format(date, "d")}
                 </p>
-                {isCurrent && (
-                  <div className="mx-auto mt-1 w-1 h-1 bg-primary rounded-full" />
-                )}
+                <div className={`mx-auto mt-1 w-1 h-1 rounded-full ${isCurrent ? "bg-primary" : "bg-transparent"}`} />
               </div>
             )
           }}

--- a/frontend/src/components/tasks/TaskList.tsx
+++ b/frontend/src/components/tasks/TaskList.tsx
@@ -1,10 +1,20 @@
 import type { TaskPublic } from "@/client/models"
 import { TasksService } from "@/client/services"
+import EditDialog from "@/components/calendar/EditDialog"
 import { useToast } from "@/hooks/use-toast"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { format, isPast, isToday, isTomorrow } from "date-fns"
-import { AnimatePresence, Reorder, motion, useDragControls } from "framer-motion"
-import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  AnimatePresence,
+  Reorder,
+  animate,
+  motion,
+  useDragControls,
+  useMotionValue,
+  useTransform,
+} from "framer-motion"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useTaskGesture } from "./useTaskGesture"
 
 const TAG_COLORS: Record<string, string> = {
   finance: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
@@ -120,6 +130,7 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
   const { toast } = useToast()
   const [orderedTasks, setOrderedTasks] = useState<TaskPublic[]>(tasks)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [editingTask, setEditingTask] = useState<TaskPublic | null>(null)
   const lastClickedId = useRef<string | null>(null)
   const isDragging = useRef(false)
   const orderedRef = useRef(orderedTasks)
@@ -168,7 +179,11 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
 
       let finalOrder = orderedRef.current
       if (selectedIds.size > 1 && selectedIds.has(draggedTaskId)) {
-        finalOrder = consolidateSelection(finalOrder, draggedTaskId, selectedIds)
+        finalOrder = consolidateSelection(
+          finalOrder,
+          draggedTaskId,
+          selectedIds,
+        )
         setOrderedTasks(finalOrder)
       }
 
@@ -178,7 +193,10 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
   )
 
   const handleTaskClick = useCallback(
-    (taskId: string, e: React.MouseEvent) => {
+    (
+      taskId: string,
+      e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean },
+    ) => {
       if (e.metaKey || e.ctrlKey) {
         setSelectedIds((prev) => {
           const next = new Set(prev)
@@ -186,6 +204,7 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
           else next.add(taskId)
           return next
         })
+        lastClickedId.current = taskId
       } else if (e.shiftKey && lastClickedId.current) {
         const ids = orderedRef.current.map((t) => t.id)
         const start = ids.indexOf(lastClickedId.current)
@@ -195,14 +214,22 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
           setSelectedIds(new Set(ids.slice(lo, hi + 1)))
         }
       } else {
-        setSelectedIds((prev) =>
-          prev.size === 1 && prev.has(taskId) ? new Set() : new Set([taskId]),
-        )
+        // Plain tap → open edit dialog
+        const task = orderedRef.current.find((t) => t.id === taskId)
+        if (task) setEditingTask(task)
       }
-      lastClickedId.current = taskId
     },
     [],
   )
+
+  const handleToggleSelection = useCallback((taskId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(taskId)) next.delete(taskId)
+      else next.add(taskId)
+      return next
+    })
+  }, [])
 
   if (orderedTasks.length === 0) {
     return (
@@ -225,9 +252,7 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
             transition={{ type: "spring", stiffness: 500, damping: 35 }}
             className="overflow-hidden"
           >
-            <div
-              className="flex items-center justify-between px-2 py-2 mb-1 bg-primary/5 rounded-lg border border-primary/10"
-            >
+            <div className="flex items-center justify-between px-2 py-2 mb-1 bg-primary/5 rounded-lg border border-primary/10">
               <span className="text-xs font-semibold text-primary">
                 {selectedIds.size} tasks selected
               </span>
@@ -253,7 +278,9 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
         {orderedTasks.map((task, i) => {
           const sel = selectedIds.has(task.id)
           const prevSel = i > 0 && selectedIds.has(orderedTasks[i - 1].id)
-          const nextSel = i < orderedTasks.length - 1 && selectedIds.has(orderedTasks[i + 1].id)
+          const nextSel =
+            i < orderedTasks.length - 1 &&
+            selectedIds.has(orderedTasks[i + 1].id)
           return (
             <TaskItem
               key={task.id}
@@ -263,10 +290,17 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
               isLastSelected={sel && !nextSel}
               onDragEnd={handleDragEnd}
               onClick={handleTaskClick}
+              onToggleSelection={handleToggleSelection}
             />
           )
         })}
       </Reorder.Group>
+
+      <EditDialog
+        task={editingTask}
+        tasks={orderedTasks}
+        onClose={() => setEditingTask(null)}
+      />
     </div>
   )
 }
@@ -278,18 +312,74 @@ function TaskItem({
   isLastSelected,
   onDragEnd,
   onClick,
+  onToggleSelection,
 }: {
   task: TaskPublic
   isSelected: boolean
   isFirstSelected: boolean
   isLastSelected: boolean
   onDragEnd: (taskId: string) => void
-  onClick: (taskId: string, e: React.MouseEvent) => void
+  onClick: (
+    taskId: string,
+    e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean },
+  ) => void
+  onToggleSelection: (taskId: string) => void
 }) {
   const [isCompleted, setIsCompleted] = useState(task.completed ?? false)
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const dragControls = useDragControls()
+
+  // Swipe animation values
+  const x = useMotionValue(0)
+  const revealOpacity = useTransform(x, [-60, -20, 0], [1, 0.3, 0])
+
+  const gestureCallbacks = useMemo(
+    () => ({
+      onTap: (e: PointerEvent) => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+          onClick(task.id, e)
+        } else {
+          onClick(task.id, { metaKey: false, ctrlKey: false, shiftKey: false })
+        }
+      },
+      onDragStart: (e: PointerEvent) => {
+        // Vertical drag (no long press) → reorder within task list
+        dragControls.start(e)
+      },
+      onLongPress: (originalEvent: PointerEvent) => {
+        // Long press → dispatch synthetic pointerdown for FC Draggable (calendar drop)
+        const taskEl = document.querySelector(`[data-task-id="${task.id}"]`)
+        if (!taskEl) return
+        bypassGesture.current = true
+        const synth = new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          clientX: originalEvent.clientX,
+          clientY: originalEvent.clientY,
+          pointerId: originalEvent.pointerId,
+          pointerType: originalEvent.pointerType,
+          isPrimary: true,
+        })
+        taskEl.dispatchEvent(synth)
+      },
+      onSwipeLeft: () => {
+        onToggleSelection(task.id)
+      },
+      onSwipeRight: () => {
+        // no-op placeholder
+      },
+      onSwipeMove: (dx: number) => {
+        x.set(dx)
+      },
+      onSwipeEnd: () => {
+        animate(x, 0, { type: "spring", stiffness: 500, damping: 30 })
+      },
+    }),
+    [task.id, onClick, onToggleSelection, dragControls, x],
+  )
+
+  const { bypassGesture, gestureBindings } = useTaskGesture(gestureCallbacks)
 
   const deleteMutation = useMutation({
     mutationFn: () => {
@@ -334,6 +424,16 @@ function TaskItem({
     toggleCompletedMutation.mutate()
   }
 
+  const selectionRounding = isSelected
+    ? isFirstSelected && isLastSelected
+      ? "rounded-[28px]"
+      : isFirstSelected
+        ? "rounded-t-[28px] rounded-b-none"
+        : isLastSelected
+          ? "rounded-b-[28px] rounded-t-none"
+          : "rounded-none"
+    : "rounded-[28px]"
+
   return (
     <Reorder.Item
       value={task}
@@ -354,100 +454,96 @@ function TaskItem({
       }}
       className="group"
     >
-      <div
-        className={`flex items-center cursor-default transition-colors duration-150 ${
-          isSelected
-            ? `bg-blue-50/80 dark:bg-blue-900/20 py-0.25 px-4 ${
-                isFirstSelected && isLastSelected
-                  ? "rounded-[28px]"
-                  : isFirstSelected
-                    ? "rounded-t-[28px] rounded-b-none"
-                    : isLastSelected
-                      ? "rounded-b-[28px] rounded-t-none"
-                      : "rounded-none"
-              }`
-            : `py-0.25 px-4 rounded-[28px] ${
-                !isCompleted ? "hover:bg-surface-container/50" : ""
-              }`
-        }`}
-        onClick={(e) => onClick(task.id, e)}
-      >
-        {/* Inner content — FC Draggable targets this for calendar drops */}
-        <div
-          data-task-id={task.id}
-          className="flex space-x-2.5 items-center flex-1 min-w-0"
+      <div className={`relative overflow-hidden ${selectionRounding}`}>
+        {/* Reveal layer (behind content) — shown on swipe left */}
+        <motion.div
+          className="absolute inset-0 flex items-center justify-end pr-4"
+          style={{ opacity: revealOpacity }}
         >
-          {/* Checkbox */}
-          <motion.button
-            whileTap={{ scale: 1.2 }}
-            onClick={handleToggleCompleted}
-            className="flex-none"
-            disabled={toggleCompletedMutation.status === "pending"}
+          <span className="material-symbols-outlined text-primary text-xl">
+            checklist
+          </span>
+        </motion.div>
+
+        {/* Sliding content */}
+        <motion.div
+          style={{ x, ...gestureBindings.style }}
+          className={`relative z-[1] cursor-default transition-colors duration-150 ${
+            isSelected
+              ? "bg-blue-50/80 dark:bg-blue-900/20"
+              : `bg-surface ${
+                  !isCompleted ? "hover:bg-surface-container/50" : ""
+                }`
+          }`}
+          onPointerDown={gestureBindings.onPointerDown}
+          onPointerMove={gestureBindings.onPointerMove}
+          onPointerUp={gestureBindings.onPointerUp}
+          onPointerCancel={gestureBindings.onPointerCancel}
+        >
+          <div
+            data-task-id={task.id}
+            className="flex space-x-2.5 items-center flex-1 min-w-0 py-0.25 px-4"
           >
-            <div
-              className={`w-4 h-4 rounded flex items-center justify-center transition-all cursor-pointer ${
+            {/* Checkbox */}
+            <motion.button
+              whileTap={{ scale: 1.2 }}
+              onClick={handleToggleCompleted}
+              className="flex-none"
+              disabled={toggleCompletedMutation.status === "pending"}
+            >
+              <div
+                className={`w-4 h-4 rounded flex items-center justify-center transition-all cursor-pointer ${
+                  isCompleted
+                    ? "bg-primary text-white"
+                    : "border-[1.5px] border-outline-variant/40 hover:border-primary/50"
+                }`}
+              >
+                {isCompleted && (
+                  <span className="material-symbols-outlined text-[12px] font-bold">
+                    check
+                  </span>
+                )}
+              </div>
+            </motion.button>
+
+            {/* Title */}
+            <p
+              className={`flex-1 min-w-0 text-sm font-medium truncate ${
                 isCompleted
-                  ? "bg-primary text-white"
-                  : "border-[1.5px] border-outline-variant/40 hover:border-primary/50"
+                  ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
+                  : "text-on-surface"
               }`}
             >
-              {isCompleted && (
-                <span className="material-symbols-outlined text-[12px] font-bold">
-                  check
-                </span>
-              )}
-            </div>
-          </motion.button>
+              {task.title}
+            </p>
 
-          {/* Title */}
-          <p
-            className={`flex-1 min-w-0 text-sm font-medium truncate ${
-              isCompleted
-                ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
-                : "text-on-surface"
-            }`}
-          >
-            {task.title}
-          </p>
+            {/* Meta (tags, due, duration) — right-aligned */}
+            <TaskMeta
+              tags={task.tags}
+              due={task.due}
+              duration={task.duration}
+            />
 
-          {/* Meta (tags, due, duration) — right-aligned */}
-          <TaskMeta tags={task.tags} due={task.due} duration={task.duration} />
-
-          <button
-            type="button"
-            className={`transition-opacity p-0.5 hover:bg-error/10 rounded ${
-              isCompleted
-                ? "invisible"
-                : "opacity-0 group-hover:opacity-100"
-            }`}
-            onClick={(e) => {
-              e.stopPropagation()
-              if (confirm("Are you sure you want to delete this task?")) {
-                deleteMutation.mutate()
-              }
-            }}
-            disabled={isCompleted || deleteMutation.status === "pending"}
-            aria-label="Delete task"
-          >
-            <span className="material-symbols-outlined text-error/60 text-base">
-              close
-            </span>
-          </button>
-        </div>
-
-        {/* Drag handle — reorder within list only (outside data-task-id so FC Draggable ignores it) */}
-        <motion.span
-          className="material-symbols-outlined text-outline-variant/40 text-lg opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing touch-none select-none ml-2.5"
-          onPointerDown={(e) => {
-            e.stopPropagation()
-            dragControls.start(e)
-          }}
-          onClick={(e) => e.stopPropagation()}
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.95 }}
-        >
-          drag_indicator
-        </motion.span>
+            <button
+              type="button"
+              className={`transition-opacity p-0.5 hover:bg-error/10 rounded ${
+                isCompleted ? "invisible" : "opacity-0 group-hover:opacity-100"
+              }`}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (confirm("Are you sure you want to delete this task?")) {
+                  deleteMutation.mutate()
+                }
+              }}
+              disabled={isCompleted || deleteMutation.status === "pending"}
+              aria-label="Delete task"
+            >
+              <span className="material-symbols-outlined text-error/60 text-base">
+                close
+              </span>
+            </button>
+          </div>
+        </motion.div>
       </div>
     </Reorder.Item>
   )

--- a/frontend/src/components/tasks/TaskList.tsx
+++ b/frontend/src/components/tasks/TaskList.tsx
@@ -61,7 +61,7 @@ function TaskMeta({
   const dueInfo = due ? formatDueDate(due) : null
 
   return (
-    <div data-testid="task-meta" className="flex items-center gap-2 mt-1">
+    <div data-testid="task-meta" className="flex items-center gap-2 shrink-0">
       {hasTags &&
         tags.map((tag) => (
           <span
@@ -226,16 +226,15 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
             className="overflow-hidden"
           >
             <div
-              className="flex items-center justify-between px-2.5 py-1.5 mb-1 rounded-lg"
-              style={{ backgroundColor: "color-mix(in srgb, var(--ds-primary) 8%, transparent)" }}
+              className="flex items-center justify-between px-2 py-2 mb-1 bg-primary/5 rounded-lg border border-primary/10"
             >
-              <span className="text-xs font-medium text-primary">
+              <span className="text-xs font-semibold text-primary">
                 {selectedIds.size} tasks selected
               </span>
               <button
                 type="button"
                 onClick={() => setSelectedIds(new Set())}
-                className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
+                className="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant/60 hover:text-primary transition-colors"
               >
                 Clear
               </button>
@@ -248,18 +247,25 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
         axis="y"
         values={orderedTasks}
         onReorder={handleReorder}
-        className="space-y-0.5"
+        className="flex flex-col"
         data-task-list-draggable
       >
-        {orderedTasks.map((task) => (
-          <TaskItem
-            key={task.id}
-            task={task}
-            isSelected={selectedIds.has(task.id)}
-            onDragEnd={handleDragEnd}
-            onClick={handleTaskClick}
-          />
-        ))}
+        {orderedTasks.map((task, i) => {
+          const sel = selectedIds.has(task.id)
+          const prevSel = i > 0 && selectedIds.has(orderedTasks[i - 1].id)
+          const nextSel = i < orderedTasks.length - 1 && selectedIds.has(orderedTasks[i + 1].id)
+          return (
+            <TaskItem
+              key={task.id}
+              task={task}
+              isSelected={sel}
+              isFirstSelected={sel && !prevSel}
+              isLastSelected={sel && !nextSel}
+              onDragEnd={handleDragEnd}
+              onClick={handleTaskClick}
+            />
+          )
+        })}
       </Reorder.Group>
     </div>
   )
@@ -268,11 +274,15 @@ export function TaskList({ tasks }: { tasks: TaskPublic[] }) {
 function TaskItem({
   task,
   isSelected,
+  isFirstSelected,
+  isLastSelected,
   onDragEnd,
   onClick,
 }: {
   task: TaskPublic
   isSelected: boolean
+  isFirstSelected: boolean
+  isLastSelected: boolean
   onDragEnd: (taskId: string) => void
   onClick: (taskId: string, e: React.MouseEvent) => void
 }) {
@@ -342,42 +352,36 @@ function TaskItem({
       transition={{
         layout: { type: "spring", stiffness: 350, damping: 30 },
       }}
-      className={`group rounded-lg border transition-colors duration-150 ${
-        isSelected
-          ? "bg-[--selection-bg] border-[--selection-border]"
-          : "border-transparent"
-      }`}
-      style={{
-        position: "relative",
-        "--selection-bg": "color-mix(in srgb, var(--ds-primary) 10%, transparent)",
-        "--selection-border": "color-mix(in srgb, var(--ds-primary) 25%, transparent)",
-      } as React.CSSProperties}
+      className="group"
     >
-      {/* Selection indicator bar */}
       <div
-        className="absolute left-0 top-1.5 bottom-1.5 w-[3px] rounded-full bg-primary transition-all duration-200"
-        style={{
-          transform: `scaleY(${isSelected ? 1 : 0})`,
-          opacity: isSelected ? 1 : 0,
-        }}
-      />
-
-      <div
-        className={`flex items-start py-2.5 px-2.5 cursor-default ${
-          !isSelected && !isCompleted ? "hover:bg-surface-container-highest/50 rounded-lg" : ""
+        className={`flex items-center cursor-default transition-colors duration-150 ${
+          isSelected
+            ? `bg-blue-50/80 dark:bg-blue-900/20 py-0.25 px-4 ${
+                isFirstSelected && isLastSelected
+                  ? "rounded-[28px]"
+                  : isFirstSelected
+                    ? "rounded-t-[28px] rounded-b-none"
+                    : isLastSelected
+                      ? "rounded-b-[28px] rounded-t-none"
+                      : "rounded-none"
+              }`
+            : `py-0.25 px-4 rounded-[28px] ${
+                !isCompleted ? "hover:bg-surface-container/50" : ""
+              }`
         }`}
         onClick={(e) => onClick(task.id, e)}
       >
         {/* Inner content — FC Draggable targets this for calendar drops */}
         <div
           data-task-id={task.id}
-          className="flex space-x-2.5 items-start flex-1 min-w-0"
+          className="flex space-x-2.5 items-center flex-1 min-w-0"
         >
           {/* Checkbox */}
           <motion.button
             whileTap={{ scale: 1.2 }}
             onClick={handleToggleCompleted}
-            className="flex-none mt-0.5"
+            className="flex-none"
             disabled={toggleCompletedMutation.status === "pending"}
           >
             <div
@@ -395,38 +399,40 @@ function TaskItem({
             </div>
           </motion.button>
 
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <p
-              className={`text-sm font-medium truncate ${
-                isCompleted
-                  ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
-                  : "text-on-surface"
-              }`}
-            >
-              {task.title}
-            </p>
-            <TaskMeta tags={task.tags} due={task.due} duration={task.duration} />
-          </div>
+          {/* Title */}
+          <p
+            className={`flex-1 min-w-0 text-sm font-medium truncate ${
+              isCompleted
+                ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
+                : "text-on-surface"
+            }`}
+          >
+            {task.title}
+          </p>
 
-          {!isCompleted && (
-            <button
-              type="button"
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:bg-error/10 rounded"
-              onClick={(e) => {
-                e.stopPropagation()
-                if (confirm("Are you sure you want to delete this task?")) {
-                  deleteMutation.mutate()
-                }
-              }}
-              disabled={deleteMutation.status === "pending"}
-              aria-label="Delete task"
-            >
-              <span className="material-symbols-outlined text-error/60 text-base">
-                close
-              </span>
-            </button>
-          )}
+          {/* Meta (tags, due, duration) — right-aligned */}
+          <TaskMeta tags={task.tags} due={task.due} duration={task.duration} />
+
+          <button
+            type="button"
+            className={`transition-opacity p-0.5 hover:bg-error/10 rounded ${
+              isCompleted
+                ? "invisible"
+                : "opacity-0 group-hover:opacity-100"
+            }`}
+            onClick={(e) => {
+              e.stopPropagation()
+              if (confirm("Are you sure you want to delete this task?")) {
+                deleteMutation.mutate()
+              }
+            }}
+            disabled={isCompleted || deleteMutation.status === "pending"}
+            aria-label="Delete task"
+          >
+            <span className="material-symbols-outlined text-error/60 text-base">
+              close
+            </span>
+          </button>
         </div>
 
         {/* Drag handle — reorder within list only (outside data-task-id so FC Draggable ignores it) */}

--- a/frontend/src/components/tasks/TaskList.tsx
+++ b/frontend/src/components/tasks/TaskList.tsx
@@ -362,72 +362,76 @@ function TaskItem({
         }}
       />
 
-      {/* Inner content — FC Draggable targets this for calendar drops */}
       <div
-        data-task-id={task.id}
-        onClick={(e) => onClick(task.id, e)}
-        className={`flex space-x-2.5 py-2.5 px-2.5 items-start cursor-default ${
+        className={`flex items-start py-2.5 px-2.5 cursor-default ${
           !isSelected && !isCompleted ? "hover:bg-surface-container-highest/50 rounded-lg" : ""
         }`}
+        onClick={(e) => onClick(task.id, e)}
       >
-        {/* Checkbox */}
-        <motion.button
-          whileTap={{ scale: 1.2 }}
-          onClick={handleToggleCompleted}
-          className="flex-none mt-0.5"
-          disabled={toggleCompletedMutation.status === "pending"}
+        {/* Inner content — FC Draggable targets this for calendar drops */}
+        <div
+          data-task-id={task.id}
+          className="flex space-x-2.5 items-start flex-1 min-w-0"
         >
-          <div
-            className={`w-4 h-4 rounded flex items-center justify-center transition-all cursor-pointer ${
-              isCompleted
-                ? "bg-primary text-white"
-                : "border-[1.5px] border-outline-variant/40 hover:border-primary/50"
-            }`}
+          {/* Checkbox */}
+          <motion.button
+            whileTap={{ scale: 1.2 }}
+            onClick={handleToggleCompleted}
+            className="flex-none mt-0.5"
+            disabled={toggleCompletedMutation.status === "pending"}
           >
-            {isCompleted && (
-              <span className="material-symbols-outlined text-[12px] font-bold">
-                check
-              </span>
-            )}
-          </div>
-        </motion.button>
+            <div
+              className={`w-4 h-4 rounded flex items-center justify-center transition-all cursor-pointer ${
+                isCompleted
+                  ? "bg-primary text-white"
+                  : "border-[1.5px] border-outline-variant/40 hover:border-primary/50"
+              }`}
+            >
+              {isCompleted && (
+                <span className="material-symbols-outlined text-[12px] font-bold">
+                  check
+                </span>
+              )}
+            </div>
+          </motion.button>
 
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          <p
-            className={`text-sm font-medium truncate ${
-              isCompleted
-                ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
-                : "text-on-surface"
-            }`}
-          >
-            {task.title}
-          </p>
-          <TaskMeta tags={task.tags} due={task.due} duration={task.duration} />
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <p
+              className={`text-sm font-medium truncate ${
+                isCompleted
+                  ? "line-through decoration-primary/30 decoration-2 text-on-surface-variant/50"
+                  : "text-on-surface"
+              }`}
+            >
+              {task.title}
+            </p>
+            <TaskMeta tags={task.tags} due={task.due} duration={task.duration} />
+          </div>
+
+          {!isCompleted && (
+            <button
+              type="button"
+              className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:bg-error/10 rounded"
+              onClick={(e) => {
+                e.stopPropagation()
+                if (confirm("Are you sure you want to delete this task?")) {
+                  deleteMutation.mutate()
+                }
+              }}
+              disabled={deleteMutation.status === "pending"}
+              aria-label="Delete task"
+            >
+              <span className="material-symbols-outlined text-error/60 text-base">
+                close
+              </span>
+            </button>
+          )}
         </div>
 
-        {!isCompleted && (
-          <button
-            type="button"
-            className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:bg-error/10 rounded"
-            onClick={(e) => {
-              e.stopPropagation()
-              if (confirm("Are you sure you want to delete this task?")) {
-                deleteMutation.mutate()
-              }
-            }}
-            disabled={deleteMutation.status === "pending"}
-            aria-label="Delete task"
-          >
-            <span className="material-symbols-outlined text-error/60 text-base">
-              close
-            </span>
-          </button>
-        )}
-
-        {/* Drag handle — reorder within list (FM) */}
+        {/* Drag handle — reorder within list only (outside data-task-id so FC Draggable ignores it) */}
         <motion.span
-          className="material-symbols-outlined text-outline-variant/40 text-lg opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing touch-none select-none"
+          className="material-symbols-outlined text-outline-variant/40 text-lg opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing touch-none select-none ml-2.5"
           onPointerDown={(e) => {
             e.stopPropagation()
             dragControls.start(e)

--- a/frontend/src/components/tasks/useTaskGesture.ts
+++ b/frontend/src/components/tasks/useTaskGesture.ts
@@ -1,0 +1,198 @@
+import { useCallback, useRef } from "react"
+
+type GestureState = "idle" | "pending" | "longpress" | "dragging" | "swiping"
+
+interface GestureCallbacks {
+  onTap: (e: PointerEvent) => void
+  onDragStart: (e: PointerEvent) => void // vertical movement → reorder
+  onLongPress: (e: PointerEvent) => void // timer fires → calendar drop
+  onSwipeLeft: () => void
+  onSwipeRight: () => void
+  onSwipeMove: (dx: number) => void // continuous x offset for animation
+  onSwipeEnd: () => void // snap back
+}
+
+const LONG_PRESS_MS = 400
+const SWIPE_THRESHOLD_PX = 10
+const DRAG_THRESHOLD_PX = 10
+const MAX_SWIPE_PX = 80
+
+/** Rubber-band: linear up to max, then heavy damping beyond */
+function rubberBand(dx: number, max: number): number {
+  const sign = Math.sign(dx)
+  const abs = Math.abs(dx)
+  if (abs <= max) return dx
+  const over = abs - max
+  return sign * (max + over * 0.12)
+}
+
+export function useTaskGesture(callbacks: GestureCallbacks) {
+  const state = useRef<GestureState>("idle")
+  const startX = useRef(0)
+  const startY = useRef(0)
+  const storedEvent = useRef<PointerEvent | null>(null)
+  const timerId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const bypassGesture = useRef(false)
+  const pointerId = useRef<number | null>(null)
+  const captureTarget = useRef<HTMLElement | null>(null)
+
+  const cleanup = useCallback(() => {
+    if (timerId.current !== null) {
+      clearTimeout(timerId.current)
+      timerId.current = null
+    }
+    state.current = "idle"
+    storedEvent.current = null
+    pointerId.current = null
+    captureTarget.current = null
+  }, [])
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (bypassGesture.current) {
+        bypassGesture.current = false
+        return
+      }
+      // Only handle primary button (left click / touch)
+      if (e.button !== 0) return
+      // Ignore clicks on buttons/inputs
+      const target = e.target as HTMLElement
+      if (target.closest("button, input, [role='button']")) return
+
+      e.stopPropagation()
+
+      state.current = "pending"
+      startX.current = e.clientX
+      startY.current = e.clientY
+      pointerId.current = e.pointerId
+      storedEvent.current = e.nativeEvent
+      captureTarget.current = e.currentTarget as HTMLElement
+
+      // Capture pointer for reliable tracking
+      try {
+        captureTarget.current.setPointerCapture(e.pointerId)
+      } catch {
+        // setPointerCapture can fail if element is removed
+      }
+
+      timerId.current = setTimeout(() => {
+        if (state.current === "pending") {
+          state.current = "longpress"
+
+          // Release capture so FC Draggable can track the pointer
+          if (captureTarget.current && pointerId.current !== null) {
+            try {
+              captureTarget.current.releasePointerCapture(pointerId.current)
+            } catch {
+              // ignore
+            }
+          }
+
+          if (storedEvent.current) {
+            callbacks.onLongPress(storedEvent.current)
+          }
+        }
+      }, LONG_PRESS_MS)
+    },
+    [callbacks],
+  )
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (state.current !== "pending" && state.current !== "swiping") return
+      if (e.pointerId !== pointerId.current) return
+
+      const dx = e.clientX - startX.current
+      const dy = e.clientY - startY.current
+
+      if (state.current === "pending") {
+        // Vertical movement > threshold → start reorder drag
+        if (Math.abs(dy) > DRAG_THRESHOLD_PX) {
+          if (timerId.current !== null) {
+            clearTimeout(timerId.current)
+            timerId.current = null
+          }
+          state.current = "dragging"
+
+          // Release capture so Reorder can take over
+          if (captureTarget.current && pointerId.current !== null) {
+            try {
+              captureTarget.current.releasePointerCapture(pointerId.current)
+            } catch {
+              // ignore
+            }
+          }
+
+          if (storedEvent.current) {
+            callbacks.onDragStart(storedEvent.current)
+          }
+          return
+        }
+        // Horizontal movement > threshold → start swiping
+        if (Math.abs(dx) > SWIPE_THRESHOLD_PX) {
+          if (timerId.current !== null) {
+            clearTimeout(timerId.current)
+            timerId.current = null
+          }
+          state.current = "swiping"
+          e.preventDefault()
+          callbacks.onSwipeMove(rubberBand(dx, MAX_SWIPE_PX))
+        }
+      } else if (state.current === "swiping") {
+        e.preventDefault()
+        callbacks.onSwipeMove(rubberBand(dx, MAX_SWIPE_PX))
+      }
+    },
+    [callbacks],
+  )
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== pointerId.current) return
+
+      const currentState = state.current
+
+      if (currentState === "pending") {
+        // Released before timer fired and within movement threshold → tap
+        cleanup()
+        callbacks.onTap(e.nativeEvent)
+      } else if (currentState === "swiping") {
+        const dx = e.clientX - startX.current
+        if (dx < -60) {
+          callbacks.onSwipeLeft()
+        } else if (dx > 60) {
+          callbacks.onSwipeRight()
+        }
+        callbacks.onSwipeEnd()
+        cleanup()
+      } else if (currentState === "longpress" || currentState === "dragging") {
+        cleanup()
+      } else {
+        cleanup()
+      }
+    },
+    [callbacks, cleanup],
+  )
+
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerId !== pointerId.current) return
+      if (state.current === "swiping") {
+        callbacks.onSwipeEnd()
+      }
+      cleanup()
+    },
+    [callbacks, cleanup],
+  )
+
+  return {
+    bypassGesture,
+    gestureBindings: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      style: { touchAction: "pan-y" as const },
+    },
+  }
+}


### PR DESCRIPTION
### What's changed

In this PR, the task items have click, hold and swipe gestures. Clicking will lead to opening the task details, holding will allow the user to move the task to the calendar (though as it stands right now, that can be done even with a quick hold-drag, rather than a long-press hold drag), and the swipe gesture allows the user to select task. There are some clear corner cases that need to be addressed and I need to iron those out, but this is a good baseline to work from for the TaskList.